### PR TITLE
Add terminal encoding option

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,18 +31,22 @@ On Kindle menu pops up on two fingers tap in the terminal window. On other devic
 ```
 $ ./kterm -h
 Usage: kterm [OPTIONS]
-        -c <0|1>     color scheme (0 light, 1 dark)
-        -d           debug mode
-        -e <command> execute command in kterm
-        -E <var>     set environment variable
-        -f <family>  font family
-        -h           show this message
-        -k <0|1>     keyboard off/on
-        -l <path>    keyboard layout config path
-        -o <U|R|L>   screen orientation (up, right, left)
-        -s <size>    font size
-        -v           print version and exit
+        -c <0|1>      color scheme (0 light, 1 dark)
+        -d            debug mode
+        -e <command>  execute command in kterm
+        -E <var>      set environment variable
+        -f <family>   font family
+        -t <encoding> terminal encoding
+        -h            show this message
+        -k <0|1>      keyboard off/on
+        -l <path>     keyboard layout config path
+        -o <U|R|L>    screen orientation (up, right, left)
+        -s <size>     font size
+        -v            print version and exit
 ```
+
+For a list of what constitutes valid encodings, check [this list][iana-character-sets] or the list returned by `iconv -l`.
+
 #### Screenshots
 ![kterm reversed color scheme][screenshot1] 
 ![kterm hidden keyboard][screenshot2]
@@ -79,3 +83,4 @@ Usage: kterm [OPTIONS]
 [screenshot1]:http://www.fabiszewski.net/kindle-terminal/screenshot_v2_1.png "kterm screenshot"
 [screenshot2]:http://www.fabiszewski.net/kindle-terminal/screenshot_v2_2.png "kterm screenshot"
 [screenshot3]:http://www.fabiszewski.net/kindle-terminal/screenshot_v2_3.png "kterm screenshot"
+[iana-character-sets]: https://www.iana.org/assignments/character-sets/character-sets.txt

--- a/config.h
+++ b/config.h
@@ -105,6 +105,7 @@ typedef struct {
     gboolean color_reversed; /** Color scheme, is reversed */
     gchar font_family[50]; /** Terminal font family */
     guint font_size;  /** Terminal font size */
+    gchar encoding[50]; /** Terminal encoding */
     gchar kb_conf_path[PATH_MAX];  /** Keyboard config path */
     gchar orientation;  /** Screen orientation: 'U', 'R' or 'L' */
     gchar orientation_saved;  /** Initial screen orientation: 'U', 'R' or 'L' */

--- a/kterm.c
+++ b/kterm.c
@@ -472,19 +472,20 @@ static void version(void) {
  */
 static void usage(void) {
     printf("Usage: kterm [OPTIONS]\n");
-    printf("        -c <0|1>     color scheme (0 light, 1 dark)\n");
-    printf("        -d           debug mode\n");
-    printf("        -e <command> execute command in kterm\n");
-    printf("        -E <var>     set environment variable\n");
-    printf("        -f <family>  font family\n");
-    printf("        -h           show this message\n");
-    printf("        -k <0|1>     keyboard off/on\n");
-    printf("        -l <path>    keyboard layout config path\n");
+    printf("        -c <0|1>      color scheme (0 light, 1 dark)\n");
+    printf("        -d            debug mode\n");
+    printf("        -e <command>  execute command in kterm\n");
+    printf("        -E <var>      set environment variable\n");
+    printf("        -f <family>   font family\n");
+    printf("        -t <encoding> terminal encoding\n");
+    printf("        -h            show this message\n");
+    printf("        -k <0|1>      keyboard off/on\n");
+    printf("        -l <path>     keyboard layout config path\n");
 #ifdef KINDLE
-    printf("        -o <U|R|L>   screen orientation (up, right, left)\n");
+    printf("        -o <U|R|L>    screen orientation (up, right, left)\n");
 #endif
-    printf("        -s <size>    font size\n");
-    printf("        -v           print version and exit\n");
+    printf("        -s <size>     font size\n");
+    printf("        -v            print version and exit\n");
     exit(0);
 }
 
@@ -520,9 +521,9 @@ static void setup_terminal(GtkWidget *terminal, gchar *command, gchar **envv, GE
     vte_terminal_set_scrollback_lines(VTE_TERMINAL(terminal), VTE_SCROLLBACK_LINES);
     set_terminal_font(VTE_TERMINAL(terminal), conf->font_family, (gint) conf->font_size);
 #if VTE_CHECK_VERSION(0,38,0)
-    vte_terminal_set_encoding(VTE_TERMINAL(terminal), VTE_ENCODING, NULL);
+    vte_terminal_set_encoding(VTE_TERMINAL(terminal), conf->encoding, NULL);
 #else
-    vte_terminal_set_encoding(VTE_TERMINAL(terminal), VTE_ENCODING);
+    vte_terminal_set_encoding(VTE_TERMINAL(terminal), conf->encoding);
 #endif
     vte_terminal_set_allow_bold(VTE_TERMINAL(terminal), TRUE);
     
@@ -602,7 +603,7 @@ gint main(gint argc, gchar **argv) {
     // set terminfo path
     envv[envc++] = "TERMINFO=" TERMINFO_PATH;
 #endif
-    while((c = getopt(argc, argv, "c:de:E:f:hk:l:o:s:v")) != -1) {
+    while((c = getopt(argc, argv, "c:de:E:f:t:hk:l:o:s:v")) != -1) {
         switch(c) {
             case 'd':
                 debug = TRUE;
@@ -635,6 +636,9 @@ gint main(gint argc, gchar **argv) {
                 break;
             case 'f':
                 snprintf(conf->font_family, sizeof(conf->font_family), "%s", optarg);
+                break;
+            case 't':
+                snprintf(conf->encoding, sizeof(conf->encoding), "%s", optarg);
                 break;
             case 'h':
                 usage();

--- a/kterm.conf
+++ b/kterm.conf
@@ -8,6 +8,8 @@ color_scheme = 0
 font_family = "Monospace"
 # font size
 font_size = 8
+# terminal encoding
+encoding = UTF-8
 # keyboard config file 
 #kb_conf_path = "/mnt/us/extensions/kterm/layouts/keyboard.xml"
 # screen orientation: U, R or L

--- a/parse_config.c
+++ b/parse_config.c
@@ -64,6 +64,7 @@ KTconf *parse_config(void) {
     conf->color_reversed = FALSE;
     conf->font_size = VTE_FONT_SIZE;
     snprintf(conf->font_family, sizeof(conf->font_family), "%s", VTE_FONT_FAMILY);
+    snprintf(conf->encoding, sizeof(conf->encoding), "%s", VTE_ENCODING);
     snprintf(conf->kb_conf_path, sizeof(conf->kb_conf_path), "%s", KB_FULL_PATH);
     conf->orientation = 0;
     
@@ -105,6 +106,12 @@ KTconf *parse_config(void) {
                 conf->font_size = font_size;
                 D printf("font_size = %u\n", conf->font_size);
             }
+        }
+        else if (!strncmp(buf, "encoding", 8)) {
+            gchar str[256];
+            sscanf(buf, "encoding = \"%[^\"\n\r]\"", str);
+            snprintf(conf->encoding, sizeof(conf->encoding), "%s", str);
+            D printf("encoding = %s\n", conf->encoding);
         }
         else if (!strncmp(buf, "kb_conf_path", 12)) {
             gchar str2[PATH_MAX];


### PR DESCRIPTION
By default, VTE initializes a UTF8 terminal (which is specifically instantiated here as such via the
VTE_ENCODING constant). However, not all applications are UTF8-aware, and some rely on hacks or
alternative encodings in order to display certain characters (*cough* *cough* Nethack).

This commit adds the required hooks and documentation for allowing us to change the terminal
encoding scheme to something other than UTF8, in an effort to cope with these broken applications.

The option character `t` was the closest thing to 'terminal encoding' I could find.