### PR TITLE
Add cursor shape customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ Usage: kterm [OPTIONS]
         -l <path>     keyboard layout config path
         -o <U|R|L>    screen orientation (up, right, left)
         -s <size>     font size
-        -u <B|I|U>    cursor shape (block, I-beam, underline)
         -t <encoding> terminal encoding
+        -u <B|I|U>    cursor shape (block, I-beam, underline)
         -v            print version and exit
 ```
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Usage: kterm [OPTIONS]
         -l <path>     keyboard layout config path
         -o <U|R|L>    screen orientation (up, right, left)
         -s <size>     font size
+        -u <B|I|U>    cursor shape (block, I-beam, underline)
         -t <encoding> terminal encoding
         -v            print version and exit
 ```

--- a/config.h
+++ b/config.h
@@ -105,6 +105,7 @@ typedef struct {
     gboolean color_reversed; /** Color scheme, is reversed */
     gchar font_family[50]; /** Terminal font family */
     guint font_size;  /** Terminal font size */
+    gchar cursor_shape;  /** Terminal cursor shape: 'B', 'I' or 'U' */
     gchar encoding[50]; /** Terminal encoding */
     gchar kb_conf_path[PATH_MAX];  /** Keyboard config path */
     gchar orientation;  /** Screen orientation: 'U', 'R' or 'L' */

--- a/kterm.c
+++ b/kterm.c
@@ -100,6 +100,7 @@ static void terminal_exit(void) {
     gtk_main_quit();
 }
 
+#if VTE_CHECK_VERSION(0,20,0)
 /**
  * Set terminal cursor shape
  * @param terminal Terminal
@@ -124,7 +125,7 @@ static void set_terminal_cursor(VteTerminal *terminal, gchar cursor_shape) {
     }
     vte_terminal_set_cursor_shape(terminal, shape);
 }
-
+#endif
 
 /**
  * Set terminal font
@@ -510,8 +511,10 @@ static void usage(void) {
     printf("        -o <U|R|L>    screen orientation (up, right, left)\n");
 #endif
     printf("        -s <size>     font size\n");
-    printf("        -u <B|I|U>    cursor shape (block, I-beam, underline)\n");
     printf("        -t <encoding> terminal encoding\n");
+#if VTE_CHECK_VERSION(0,20,0)
+    printf("        -u <B|I|U>    cursor shape (block, I-beam, underline)\n");
+#endif
     printf("        -v            print version and exit\n");
     exit(0);
 }
@@ -547,7 +550,9 @@ static void setup_terminal(GtkWidget *terminal, gchar *command, gchar **envv, GE
     set_terminal_colors(terminal, conf->color_reversed);
     vte_terminal_set_scrollback_lines(VTE_TERMINAL(terminal), VTE_SCROLLBACK_LINES);
     set_terminal_font(VTE_TERMINAL(terminal), conf->font_family, (gint) conf->font_size);
+#if VTE_CHECK_VERSION(0,20,0)
     set_terminal_cursor(VTE_TERMINAL(terminal), conf->cursor_shape);
+#endif
 #if VTE_CHECK_VERSION(0,38,0)
     vte_terminal_set_encoding(VTE_TERMINAL(terminal), conf->encoding, NULL);
 #else
@@ -631,7 +636,7 @@ gint main(gint argc, gchar **argv) {
     // set terminfo path
     envv[envc++] = "TERMINFO=" TERMINFO_PATH;
 #endif
-    while((c = getopt(argc, argv, "c:de:E:f:hk:l:o:s:u:t:v")) != -1) {
+    while((c = getopt(argc, argv, "c:de:E:f:hk:l:o:s:t:u:v")) != -1) {
         switch(c) {
             case 'd':
                 debug = TRUE;
@@ -662,14 +667,14 @@ gint main(gint argc, gchar **argv) {
                 i = atoi(optarg);
                 if (i > 0) conf->font_size = (guint) i;
                 break;
-            case 'u':
-                if (optarg[0] == 'B' || optarg[0] == 'I' || optarg[0] == 'U') { conf->cursor_shape = optarg[0]; }
-                break;
             case 'f':
                 snprintf(conf->font_family, sizeof(conf->font_family), "%s", optarg);
                 break;
             case 't':
                 snprintf(conf->encoding, sizeof(conf->encoding), "%s", optarg);
+                break;
+            case 'u':
+                if (optarg[0] == 'B' || optarg[0] == 'I' || optarg[0] == 'U') { conf->cursor_shape = optarg[0]; }
                 break;
             case 'h':
                 usage();

--- a/kterm.c
+++ b/kterm.c
@@ -101,6 +101,28 @@ static void terminal_exit(void) {
 }
 
 /**
+ * Set terminal cursor shape
+ * @param terminal Terminal
+ * @param cursor_shape Letter representing desired shape ('B', 'I' or 'U')
+ */
+static void set_terminal_cursor(VteTerminal *terminal, gchar cursor_shape) {
+    VteTerminalCursorShape shape = 0;
+    switch (cursor_shape) {
+        case 'B':
+            shape = VTE_CURSOR_SHAPE_BLOCK;
+            break;
+        case 'I':
+            shape = VTE_CURSOR_SHAPE_IBEAM;
+            break;
+        case 'U':
+            shape = VTE_CURSOR_SHAPE_UNDERLINE;
+            break;
+    }
+    vte_terminal_set_cursor_shape(terminal, shape);
+}
+
+
+/**
  * Set terminal font
  * @param terminal Terminal
  * @param font_family Font family
@@ -484,6 +506,7 @@ static void usage(void) {
     printf("        -o <U|R|L>    screen orientation (up, right, left)\n");
 #endif
     printf("        -s <size>     font size\n");
+    printf("        -u <B|I|U>    cursor shape (block, I-beam, underline)\n");
     printf("        -t <encoding> terminal encoding\n");
     printf("        -v            print version and exit\n");
     exit(0);
@@ -520,6 +543,7 @@ static void setup_terminal(GtkWidget *terminal, gchar *command, gchar **envv, GE
     set_terminal_colors(terminal, conf->color_reversed);
     vte_terminal_set_scrollback_lines(VTE_TERMINAL(terminal), VTE_SCROLLBACK_LINES);
     set_terminal_font(VTE_TERMINAL(terminal), conf->font_family, (gint) conf->font_size);
+    set_terminal_cursor(VTE_TERMINAL(terminal), conf->cursor_shape);
 #if VTE_CHECK_VERSION(0,38,0)
     vte_terminal_set_encoding(VTE_TERMINAL(terminal), conf->encoding, NULL);
 #else
@@ -603,7 +627,7 @@ gint main(gint argc, gchar **argv) {
     // set terminfo path
     envv[envc++] = "TERMINFO=" TERMINFO_PATH;
 #endif
-    while((c = getopt(argc, argv, "c:de:E:f:hk:l:o:s:t:v")) != -1) {
+    while((c = getopt(argc, argv, "c:de:E:f:hk:l:o:s:u:t:v")) != -1) {
         switch(c) {
             case 'd':
                 debug = TRUE;
@@ -633,6 +657,9 @@ gint main(gint argc, gchar **argv) {
             case 's':
                 i = atoi(optarg);
                 if (i > 0) conf->font_size = (guint) i;
+                break;
+            case 'u':
+                if (optarg[0] == 'B' || optarg[0] == 'I' || optarg[0] == 'U') { conf->cursor_shape = optarg[0]; }
                 break;
             case 'f':
                 snprintf(conf->font_family, sizeof(conf->font_family), "%s", optarg);

--- a/kterm.c
+++ b/kterm.c
@@ -106,7 +106,11 @@ static void terminal_exit(void) {
  * @param cursor_shape Letter representing desired shape ('B', 'I' or 'U')
  */
 static void set_terminal_cursor(VteTerminal *terminal, gchar cursor_shape) {
+#if VTE_CHECK_VERSION(0,38,0)
+    VteCursorShape shape = 0;
+#else
     VteTerminalCursorShape shape = 0;
+#endif
     switch (cursor_shape) {
         case 'B':
             shape = VTE_CURSOR_SHAPE_BLOCK;

--- a/kterm.conf
+++ b/kterm.conf
@@ -14,3 +14,5 @@ font_size = 8
 #kb_conf_path = "/mnt/us/extensions/kterm/layouts/keyboard.xml"
 # screen orientation: U, R or L
 #orientation = U
+# cursor shape: B, I, or U
+#cursor_shape = B

--- a/parse_config.c
+++ b/parse_config.c
@@ -127,6 +127,14 @@ KTconf *parse_config(void) {
                 D printf("orientation = %c\n", conf->orientation);
             }
         }
+        else if (!strncmp(buf, "cursor_shape", 12)) {
+            gchar cursor_shape = 0;
+            sscanf(buf, "cursor_shape = %c", &cursor_shape);
+            if (cursor_shape == 'B' || cursor_shape == 'I' || cursor_shape == 'U') {
+                conf->cursor_shape = cursor_shape;
+                D printf("cursor_shape = %c\n", conf->cursor_shape);
+            }
+        }
     }
     
     fclose(fp);


### PR DESCRIPTION
The default block cursor seems a bit "heavy" for e-ink, so we might as well expose `vte_terminal_set_cursor_shape` to be configured with `-u <B|I|U>`.  Picked `-u` as the flag because it's one of the few letters in `cursor` that are still unused but maybe something else makes more sense.  